### PR TITLE
Updated swift template for RHMAP-6902

### DIFF
--- a/Storyboard.storyboard
+++ b/Storyboard.storyboard
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="1cA-hw-Lzo">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="1cA-hw-Lzo">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
         <!--Home View Controller-->
         <scene sceneID="eEO-c2-sVR">
             <objects>
-                <viewController id="1cA-hw-Lzo" customClass="HomeViewController" customModule="Helloworld_app_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="1cA-hw-Lzo" customClass="HomeViewController" customModule="helloworld_ios_app" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="ijn-Ly-QGs"/>
                         <viewControllerLayoutGuide type="bottom" id="pc3-P4-lEh"/>
@@ -17,10 +18,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <textView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" alpha="0.45000000000000001" contentMode="scaleToFill" editable="NO" text="Response here." selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5cB-VR-dcX">
+                            <textView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" alpha="0.45000000000000001" contentMode="scaleToFill" editable="NO" text="Response here." translatesAutoresizingMaskIntoConstraints="NO" id="5cB-VR-dcX">
                                 <rect key="frame" x="0.0" y="300" width="600" height="300"/>
                                 <color key="backgroundColor" red="0.0" green="0.233641805333173" blue="0.49113343253968256" alpha="1" colorSpace="calibratedRGB"/>
                                 <color key="tintColor" red="1" green="0.98823535439999999" blue="0.9215686917" alpha="1" colorSpace="deviceRGB"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
@@ -59,7 +61,7 @@
                                             <rect key="frame" x="8" y="36" width="384" height="55"/>
                                         </variation>
                                     </label>
-                                    <textField opaque="NO" clipsSubviews="YES" alpha="0.65000000000000002" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="World" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="1Kj-tb-HtK">
+                                    <textField opaque="NO" clipsSubviews="YES" alpha="0.65000000000000002" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="World" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="1Kj-tb-HtK">
                                         <rect key="frame" x="8" y="190" width="584" height="47"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="calibratedRGB"/>
                                         <constraints>


### PR DESCRIPTION
"Result" UITextView is now selectable to avoid a bug that resets the default font and color when the text is set.
Changed "Result" UITextView default color to white to add higher contrast. 
Changed "Name" UITextField Border Style to UITextBorderStyleRoundedRect so it has some padding.
