### PR TITLE
Move build status markdown to new line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# helloworld-ios-swift [![Build Status](https://travis-ci.org/feedhenry-templates/helloworld-ios-swift.png)](https://travis-ci.org/feedhenry-templates/helloworld-ios-swift)
+# helloworld-ios-swift
+[![Build Status](https://travis-ci.org/feedhenry-templates/helloworld-ios-swift.png)](https://travis-ci.org/feedhenry-templates/helloworld-ios-swift)
 
 > Obj-C version is available [here](https://github.com/feedhenry-templates/helloworld-ios).
 


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/FH-3422

Motivation: Studio cannot convert the markdown if it's on the same line as the header